### PR TITLE
fix redcolor 1 and bluecolor 1 to redcolor and bluecolor

### DIFF
--- a/lab2/index.md
+++ b/lab2/index.md
@@ -58,7 +58,7 @@ the duration of on pulses through the serial port.
      end of each message, you should loop infinitely. You may assume that the first character 
      will be either a dot or a dash (not a space). **(50 pts)**
   6. Your code should flash either the blue or red LED on the launchpad. The led color
-     will be specified as either `#define REDCOLOR 1` for red or `#define BLUECOLOR 1` for blue.
+     will be specified as either `#define REDCOLOR` for red or `#define BLUECOLOR` for blue.
      One or the other will be set, but not both. **(10 pts)**
   7. Your "dot" unit should be roughly 100 ms long, or 3277 clock cycles. **(20 pts)**
   8. Your morse code output should be cycle precise for arbitrary messages. **(10 pts)**


### PR DESCRIPTION
redcolor 1 and bluecolor 1 give warnings due to space between color and 1. noticed that testing was done directly using redcolor and bluecolor, so just removing 1 from the directions